### PR TITLE
ci: Fix CodeQL build failure caused by ASan conflict

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,7 @@ jobs:
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
     - run: |
-        cmake -B build -DCMAKE_BUILD_TYPE=Debug 
+        cmake -B build -DCMAKE_BUILD_TYPE=Release
         cmake --build build
 
     - name: Perform CodeQL Analysis


### PR DESCRIPTION
## Summary
- CodeQL workflow was building with `Debug`, which enables ASan (`-fsanitize=address`)
- When `protoc` executes to generate `.pb.cc` files, ASan runtime conflicts with CodeQL's instrumentation, crashing the build
- Switch to `Release` — CodeQL has its own analysis and doesn't need sanitizers

## Test plan
- [ ] Verify CodeQL CI passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)